### PR TITLE
Add class for comment total to .comment-count-area

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,4 +13,4 @@ This repository is for development purposes. If you checkout this repository, or
 ### Contributing
 Pull requests are welcome. Please do not submit pull requests against master. Please use the development branch for the next version.
 
-At this time dev-2.0-m2 branch is the correct branch to submit pull requests. 
+At this time 2.0-dev branch is the correct branch to submit pull requests. 

--- a/README.md
+++ b/README.md
@@ -13,4 +13,4 @@ This repository is for development purposes. If you checkout this repository, or
 ### Contributing
 Pull requests are welcome. Please do not submit pull requests against master. Please use the development branch for the next version.
 
-At this time 1.0.6-dev branch is the correct branch to submit pull requests.
+At this time dev-2.0-m2 branch is the correct branch to submit pull requests. 

--- a/classes/front/templates/initial.php
+++ b/classes/front/templates/initial.php
@@ -43,13 +43,15 @@ if ( 'none' == $options[ 'theme' ] ) {
 
 	if ( 'ASC' == $options['order'] && $comment_count > 3 && 'iframe' != $options['theme'] ) {
 		$comment_count_area = sprintf(
-			'<h3 class="comment-count-area">%1s <a href="#reply-title">%2s</a></h3>',
+			'<h3 class="comment-count-area comment-total-%1d">%2s <a href="#reply-title">%3s</a></h3>',
+			$comment_count,
 			$comment_count_message,
 			$options['before_text']
 		);
 	} else {
 		$comment_count_area = sprintf(
-			'<h3 class="comment-count-area">%1s</h3>',
+			'<h3 class="comment-count-area comment-total-%1$d">%2s</h3>',
+			$comment_count,
 			$comment_count_message
 		);
 	}


### PR DESCRIPTION
This was my workaround for a client who didn't want the default "There are no comments" text displayed.  Arguably this could also be another option, like "Headline" (before_text).